### PR TITLE
mark the "no change" formats as stable

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -357,6 +357,7 @@ export const FluidClientVersion: {
     readonly v2_52: "2.52.0";
     readonly v2_73: "2.73.0";
     readonly v2_74: "2.74.0";
+    readonly v2_80: "2.80.0";
 };
 
 // @beta
@@ -1063,7 +1064,6 @@ export interface SharedTreeFormatOptions {
 
 // @alpha @input
 export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions> {
-    readonly enableAlphaConstraints?: boolean;
     readonly enableSharedBranches?: boolean;
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
 }

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -548,6 +548,17 @@ export const FluidClientVersion = {
 	 * - ForestSummaryFormatVersion.v3 - written when minVersionForCollab \>= 2.74
 	 */
 	v2_74: "2.74.0",
+
+	/**
+	 * Fluid Framework Client 2.80 and newer.
+	 * @remarks
+	 * New formats introduced in 2.80:
+	 * - MessageFormatVersion.v6 - written when minVersionForCollab \>= 2.80
+	 * - EditManagerFormatVersion.v6 - written when minVersionForCollab \>= 2.80
+	 * - SharedTreeChangeFormatVersion.v5 - written when minVersionForCollab \>= 2.80
+	 * - ModularChangeFormatVersion.v5 - written when minVersionForCollab \>= 2.80
+	 */
+	v2_80: "2.80.0",
 } as const satisfies Record<string, MinimumVersionForCollab>;
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -58,6 +58,7 @@ export function clientVersionToEditManagerFormatVersion(
 		getConfigForMinVersionForCollab(clientVersion, {
 			[lowestMinVersionForCollab]: EditManagerFormatVersion.v3,
 			[FluidClientVersion.v2_43]: EditManagerFormatVersion.v4,
+			[FluidClientVersion.v2_80]: EditManagerFormatVersion.v6,
 		}),
 	);
 
@@ -71,15 +72,6 @@ export function editManagerFormatVersionSelectorForSharedBranches(
 	clientVersion: MinimumVersionForCollab,
 ): EditManagerFormatVersion {
 	return brand(EditManagerFormatVersion.vSharedBranches);
-}
-
-/**
- * Returns the version that should be used for testing alpha constraints.
- */
-export function editManagerFormatVersionSelectorForConstraints(
-	clientVersion: MinimumVersionForCollab,
-): EditManagerFormatVersion {
-	return brand(EditManagerFormatVersion.vAlphaConstraints);
 }
 
 export interface EditManagerCodecOptions {
@@ -147,7 +139,8 @@ export function makeEditManagerCodecs<TChangeset>(
 			case unbrand(EditManagerFormatVersion.v2):
 				return [version, makeDiscontinuedCodecVersion(options, version, "2.73.0")];
 			case unbrand(EditManagerFormatVersion.v3):
-			case unbrand(EditManagerFormatVersion.v4): {
+			case unbrand(EditManagerFormatVersion.v4):
+			case unbrand(EditManagerFormatVersion.v6): {
 				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
 				return [
 					version,
@@ -161,13 +154,6 @@ export function makeEditManagerCodecs<TChangeset>(
 				return [
 					version,
 					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			case unbrand(EditManagerFormatVersion.vAlphaConstraints): {
-				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
-				return [
-					version,
-					makeV1CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
 			default:

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -157,23 +157,23 @@ export const EditManagerFormatVersion = strictEnum("editManager.FormatVersion", 
 	 */
 	v5: 5,
 	/**
+	 * Introduced and made available for writing in 2.80.0
+	 * Adds support for "no change" constraints.
+	 */
+	v6: 6,
+	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
 	vSharedBranches: "shared-branches|v0.1",
-	/**
-	 * Not yet released.
-	 * Used for new constraints.
-	 */
-	vAlphaConstraints: "alphaconstraints|v0.1",
 });
 export type EditManagerFormatVersion = Values<typeof EditManagerFormatVersion>;
 export const supportedEditManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> =
 	new Set([
 		EditManagerFormatVersion.v3,
 		EditManagerFormatVersion.v4,
+		EditManagerFormatVersion.v6,
 		EditManagerFormatVersion.vSharedBranches,
-		EditManagerFormatVersion.vAlphaConstraints,
 	]);
 export const editManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> = new Set(
 	Object.values(EditManagerFormatVersion),

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatV1toV4.ts
@@ -27,7 +27,7 @@ export interface EncodedEditManager<TChangeset> {
 		| typeof EditManagerFormatVersion.v2
 		| typeof EditManagerFormatVersion.v3
 		| typeof EditManagerFormatVersion.v4
-		| typeof EditManagerFormatVersion.vAlphaConstraints;
+		| typeof EditManagerFormatVersion.v6;
 }
 
 export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
@@ -38,7 +38,7 @@ export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: Change
 				Type.Literal(EditManagerFormatVersion.v2),
 				Type.Literal(EditManagerFormatVersion.v3),
 				Type.Literal(EditManagerFormatVersion.v4),
-				Type.Literal(EditManagerFormatVersion.vAlphaConstraints),
+				Type.Literal(EditManagerFormatVersion.v6),
 			]),
 			trunk: Type.Array(SequencedCommit(tChange)),
 			branches: Type.Array(Type.Tuple([SessionIdSchema, SummarySessionBranch(tChange)])),

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -51,7 +51,6 @@ export {
 	type EditManagerCodecOptions,
 	clientVersionToEditManagerFormatVersion,
 	editManagerFormatVersionSelectorForSharedBranches,
-	editManagerFormatVersionSelectorForConstraints,
 } from "./editManagerCodecs.js";
 export {
 	EditManagerFormatVersion,
@@ -77,7 +76,6 @@ export {
 	getCodecTreeForMessageFormatWithChange,
 	clientVersionToMessageFormatVersion,
 	messageFormatVersionSelectorForSharedBranches,
-	messageFormatVersionSelectorForConstraints,
 	makeMessageCodec,
 	type MessageEncodingContext,
 } from "./messageCodecs.js";

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -34,7 +34,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		| typeof MessageFormatVersion.v2
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
-		| typeof MessageFormatVersion.vAlphaConstraints,
+		| typeof MessageFormatVersion.v6,
 ): IJsonCodec<
 	DecodedMessage<TChangeset>,
 	JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -55,6 +55,7 @@ export function clientVersionToMessageFormatVersion(
 		getConfigForMinVersionForCollab(clientVersion, {
 			[lowestMinVersionForCollab]: MessageFormatVersion.v3,
 			[FluidClientVersion.v2_43]: MessageFormatVersion.v4,
+			[FluidClientVersion.v2_80]: MessageFormatVersion.v6,
 		}),
 	);
 	return writeVersionOverride ?? compatibleVersion;
@@ -80,15 +81,6 @@ export function messageFormatVersionSelectorForSharedBranches(
 	clientVersion: MinimumVersionForCollab,
 ): MessageFormatVersion {
 	return brand(MessageFormatVersion.vSharedBranches);
-}
-
-/**
- * Returns the version that should be used for testing table constraints.
- */
-export function messageFormatVersionSelectorForConstraints(
-	clientVersion: MinimumVersionForCollab,
-): MessageFormatVersion {
-	return brand(MessageFormatVersion.vAlphaConstraints);
 }
 
 export function makeMessageCodec<TChangeset>(
@@ -152,7 +144,8 @@ export function makeMessageCodecs<TChangeset>(
 				];
 			}
 			case unbrand(MessageFormatVersion.v3):
-			case unbrand(MessageFormatVersion.v4): {
+			case unbrand(MessageFormatVersion.v4):
+			case unbrand(MessageFormatVersion.v6): {
 				const changeCodec = changeCodecs.resolve(
 					dependentChangeFormatVersion.lookup(version),
 				).json;
@@ -170,15 +163,6 @@ export function makeMessageCodecs<TChangeset>(
 				return [
 					version,
 					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			case unbrand(MessageFormatVersion.vAlphaConstraints): {
-				const changeCodec = changeCodecs.resolve(
-					dependentChangeFormatVersion.lookup(version),
-				).json;
-				return [
-					version,
-					makeV1ToV4CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
 			default:

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -48,22 +48,22 @@ export const MessageFormatVersion = strictEnum("MessageFormatVersion", {
 	 */
 	v5: 5,
 	/**
+	 * Introduced and made available for writing in 2.80.0
+	 * Adds support for "no change" constraints.
+	 */
+	v6: 6,
+	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
 	vSharedBranches: "shared-branches|v0.1",
-	/**
-	 * Not yet released.
-	 * Only used for version alpha constraints.
-	 */
-	vAlphaConstraints: "alphaconstraints|v0.1",
 });
 export type MessageFormatVersion = Values<typeof MessageFormatVersion>;
 export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set([
 	MessageFormatVersion.v3,
 	MessageFormatVersion.v4,
+	MessageFormatVersion.v6,
 	MessageFormatVersion.vSharedBranches,
-	MessageFormatVersion.vAlphaConstraints,
 ]);
 export const messageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set(
 	Object.values(MessageFormatVersion),

--- a/packages/dds/tree/src/shared-tree-core/messageFormatV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatV1ToV4.ts
@@ -38,7 +38,7 @@ export interface Message {
 		| typeof MessageFormatVersion.v2
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
-		| typeof MessageFormatVersion.vAlphaConstraints;
+		| typeof MessageFormatVersion.v6;
 }
 
 // Return type is intentionally derived.
@@ -54,7 +54,7 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 				Type.Literal(MessageFormatVersion.v2),
 				Type.Literal(MessageFormatVersion.v3),
 				Type.Literal(MessageFormatVersion.v4),
-				Type.Literal(MessageFormatVersion.vAlphaConstraints),
+				Type.Literal(MessageFormatVersion.v6),
 			]),
 		),
 	});

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -600,7 +600,7 @@ export const changeFormatVersionForEditManager = DependentFormatVersion.fromPair
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.vAlphaConstraints),
+		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v6),
 		brand<SharedTreeChangeFormatVersion>(5),
 	],
 ]);
@@ -625,7 +625,7 @@ export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs([
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 	[
-		brand<MessageFormatVersion>(MessageFormatVersion.vAlphaConstraints),
+		brand<MessageFormatVersion>(MessageFormatVersion.v6),
 		brand<SharedTreeChangeFormatVersion>(5),
 	],
 ]);
@@ -683,12 +683,6 @@ export interface SharedTreeOptions
 	 * Defaults to false.
 	 */
 	readonly enableSharedBranches?: boolean;
-	/**
-	 * Experimental feature flag to enable alpha constraints.
-	 * This feature is not yet complete and should not be used in production.
-	 * Defaults to false.
-	 */
-	readonly enableAlphaConstraints?: boolean;
 	/**
 	 * Returns whether a node / field should be incrementally encoded.
 	 * @remarks
@@ -829,7 +823,6 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	editManagerFormatSelector: clientVersionToEditManagerFormatVersion,
 	messageFormatSelector: clientVersionToMessageFormatVersion,
 	enableSharedBranches: false,
-	enableAlphaConstraints: false,
 };
 
 /**

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1724,7 +1724,7 @@ describe("SharedTree", () => {
 				2,
 				configuredSharedTree({
 					jsonValidator: FormatValidatorBasic,
-					enableAlphaConstraints: true,
+					minVersionForCollab: FluidClientVersion.v2_80,
 				}).getFactory(),
 			);
 			const config = new TreeViewConfiguration({
@@ -1778,7 +1778,7 @@ describe("SharedTree", () => {
 				2,
 				configuredSharedTree({
 					jsonValidator: FormatValidatorBasic,
-					enableAlphaConstraints: true,
+					minVersionForCollab: FluidClientVersion.v2_80,
 				}).getFactory(),
 			);
 			const config = new TreeViewConfiguration({

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -31,8 +31,6 @@ import { FluidClientVersion } from "./codec/index.js";
 import {
 	editManagerFormatVersionSelectorForSharedBranches,
 	messageFormatVersionSelectorForSharedBranches,
-	messageFormatVersionSelectorForConstraints,
-	editManagerFormatVersionSelectorForConstraints,
 } from "./shared-tree-core/index.js";
 
 /**
@@ -215,18 +213,9 @@ export function resolveOptions(options: SharedTreeOptions): SharedTreeOptionsInt
 
 function resolveFormatOptions(options: SharedTreeOptions): SharedTreeOptionsInternal {
 	const enableSharedBranches = options.enableSharedBranches ?? false;
-	const enableAlphaConstraints = options.enableAlphaConstraints ?? false;
-	if (enableSharedBranches && enableAlphaConstraints) {
-		throw new UsageError(
-			"Cannot enable both shared branches and alpha constraints at the same time.",
-		);
-	}
 
 	if (enableSharedBranches) {
 		return sharedBranchesOptions;
-	}
-	if (enableAlphaConstraints) {
-		return alphaConstraintOptions;
 	}
 
 	return {};
@@ -235,9 +224,4 @@ function resolveFormatOptions(options: SharedTreeOptions): SharedTreeOptionsInte
 const sharedBranchesOptions: SharedTreeOptionsInternal = {
 	messageFormatSelector: messageFormatVersionSelectorForSharedBranches,
 	editManagerFormatSelector: editManagerFormatVersionSelectorForSharedBranches,
-};
-
-const alphaConstraintOptions: SharedTreeOptionsInternal = {
-	messageFormatSelector: messageFormatVersionSelectorForConstraints,
-	editManagerFormatSelector: editManagerFormatVersionSelectorForConstraints,
 };

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -411,6 +411,7 @@ export const FluidClientVersion: {
     readonly v2_52: "2.52.0";
     readonly v2_73: "2.73.0";
     readonly v2_74: "2.74.0";
+    readonly v2_80: "2.80.0";
 };
 
 // @public
@@ -1441,7 +1442,6 @@ export interface SharedTreeFormatOptions {
 
 // @alpha @input
 export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions> {
-    readonly enableAlphaConstraints?: boolean;
     readonly enableSharedBranches?: boolean;
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
 }


### PR DESCRIPTION
The required changes to mark the new formats as stable