### PR TITLE
fix: updating how auth info is encoded for github

### DIFF
--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -42,7 +42,6 @@ steps:
     echo "Target branch: $SYSTEM_PULLREQUEST_TARGETBRANCH"
 
     # Normalize branch name (refs/heads/ai/foo -> ai/foo)
-    SRC_BRANCH="${SYSTEM_PULLREQUEST_SOURCEBRANCH#refs/heads/}"
     GH_BRANCH="ado-${SYSTEM_PULLREQUEST_PULLREQUESTID}"
 
     echo "GitHub branch will be: $GH_BRANCH"
@@ -50,9 +49,9 @@ steps:
     # ---- Fetch PR title + description from ADO ----
     ADO_PR_API="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_apis/git/repositories/${BUILD_REPOSITORY_ID}/pullRequests/${SYSTEM_PULLREQUEST_PULLREQUESTID}?api-version=7.1"
 
-    PR_JSON=$(curl -sS \
+    PR_JSON=$(curl -sS --fail \
       -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-      "$ADO_PR_API")
+      "$ADO_PR_API" || { echo "Failed to fetch PR details"; exit 1; })
 
     PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
     PR_DESC=$(echo "$PR_JSON" | jq -r '.description')
@@ -98,12 +97,21 @@ steps:
 
     echo "Creating GitHub PR..."
 
-    curl -sS -X POST \
+    RESPONSE=$(curl -sS -w "%{http_code}" -o response.txt -X POST \
       -H "Authorization: token ${GITHUB_PAT}" \
       -H "Accept: application/vnd.github+json" \
       https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls \
-      -d "$CREATE_PR_PAYLOAD" \
-      || echo "PR may already exist — branch updated."
+      -d "$CREATE_PR_PAYLOAD")
+
+    if [ "$RESPONSE" -eq 201 ]; then
+      echo "GitHub PR created successfully."
+    elif [ "$RESPONSE" -eq 422 ]; then
+      echo "PR may already exist — branch updated."
+    else
+      echo "Failed to create GitHub PR. HTTP status: $RESPONSE"
+      cat response.txt
+      exit 1
+    fi
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -62,14 +62,11 @@ steps:
     echo "== PR Description =="
     echo "$PR_DESC"
 
-    # ---- Push branch to GitHub ----
-    git remote remove github 2>/dev/null || true
-    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
-
     # Map GitHub PAT into an env var (ADO secret variable -> env var)
     B64_AUTH=$(printf "x-access-token:%s" "${GITHUB_PAT}" | base64 | tr -d '\n')
     export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: Basic ${B64_AUTH}"
 
+    # ---- Push branch to GitHub ----
     # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -1,0 +1,98 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+      - ai/*
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+- group: ai-pr-bot-secrets
+- name: GITHUB_OWNER
+  value: microsoft
+- name: GITHUB_REPO
+  value: FluidFramework
+- name: GITHUB_BASE_BRANCH
+  value: main
+
+steps:
+- checkout: self
+  persistCredentials: true
+
+- bash: |
+    set -euo pipefail
+
+    echo "== Azure DevOps PR Context =="
+    echo "PR ID: $SYSTEM_PULLREQUEST_PULLREQUESTID"
+    echo "Source branch: $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+    echo "Target branch: $SYSTEM_PULLREQUEST_TARGETBRANCH"
+
+    # Normalize branch name (refs/heads/ai/foo -> ai/foo)
+    SRC_BRANCH="${SYSTEM_PULLREQUEST_SOURCEBRANCH#refs/heads/}"
+    GH_BRANCH="ado-${SYSTEM_PULLREQUEST_PULLREQUESTID}"
+
+    echo "GitHub branch will be: $GH_BRANCH"
+
+    # ---- Fetch PR title + description from ADO ----
+    ADO_PR_API="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_apis/git/repositories/${BUILD_REPOSITORY_ID}/pullRequests/${SYSTEM_PULLREQUEST_PULLREQUESTID}?api-version=7.1"
+
+    PR_JSON=$(curl -sS \
+      -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+      "$ADO_PR_API")
+
+    PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+    PR_DESC=$(echo "$PR_JSON" | jq -r '.description')
+
+    echo "== PR Title =="
+    echo "$PR_TITLE"
+
+    echo "== PR Description =="
+    echo "$PR_DESC"
+
+    # ---- Push branch to GitHub ----
+    git remote remove github 2>/dev/null || true
+    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
+
+    git config --global http.extraheader "Authorization: Bearer $GITHUB_PAT"
+
+
+    git push github HEAD:refs/heads/$GH_BRANCH --force
+
+    # ---- Build PR body safely (multiline-safe) ----
+    PR_BODY="$(cat <<EOF
+    ${PR_DESC}
+
+    🔗 **Source ADO PR:**
+    ${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_git/${BUILD_REPOSITORY_NAME}/pullrequest/${SYSTEM_PULLREQUEST_PULLREQUESTID}
+    EOF
+    )"
+
+    # ---- Create GitHub PR payload ----
+    CREATE_PR_PAYLOAD="$(jq -n \
+      --arg title "$PR_TITLE" \
+      --arg head "$GH_BRANCH" \
+      --arg base "$GITHUB_BASE_BRANCH" \
+      --arg body "$PR_BODY" \
+      '{
+        title: $title,
+        head: $head,
+        base: $base,
+        body: $body,
+        draft: true
+      }'
+    )"
+
+    echo "Creating GitHub PR..."
+
+    curl -sS -X POST \
+      -H "Authorization: token ${GITHUB_PAT}" \
+      -H "Accept: application/vnd.github+json" \
+      https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls \
+      -d "$CREATE_PR_PAYLOAD" \
+      || echo "PR may already exist — branch updated."
+
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    GITHUB_PAT: $(GITHUB_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -67,7 +67,8 @@ steps:
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
     # Map GitHub PAT into an env var (ADO secret variable -> env var)
-    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: bearer ${GITHUB_PAT}"
+    B64_AUTH=$(printf "x-access-token:%s" "${GITHUB_PAT}" | base64 | tr -d '\n')
+    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: Basic ${B64_AUTH}"
 
     # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
     git remote remove github 2>/dev/null || true

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -121,4 +121,4 @@ steps:
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    GITHUB_PAT: $(GH_PAT)
+    GITHUB_PAT: $(GH_TEMP_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -66,10 +66,15 @@ steps:
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
-    git config --global http.extraheader "Authorization: Bearer $GITHUB_PAT"
+    # Map GitHub PAT into an env var (ADO secret variable -> env var)
+    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: bearer ${GITHUB_PAT}"
 
+    # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
+    git remote remove github 2>/dev/null || true
+    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
-    git push github HEAD:refs/heads/$GH_BRANCH --force
+    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
+      push github "HEAD:refs/heads/${GH_BRANCH}"
 
     # ---- Build PR body safely (multiline-safe) ----
     PR_BODY="$(cat <<EOF

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
       - ai/*
+      - copilot/*
 
 pool:
   vmImage: ubuntu-latest

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -11,7 +11,7 @@ pool:
 variables:
 - group: ai-pr-bot-secrets
 - name: GITHUB_OWNER
-  value: microsoft
+  value: jumyhre # TODO: Change to microsoft when ready
 - name: GITHUB_REPO
   value: FluidFramework
 - name: GITHUB_BASE_BRANCH

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -95,4 +95,4 @@ steps:
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    GITHUB_PAT: $(GITHUB_PAT)
+    GITHUB_PAT: $(GH_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -74,8 +74,12 @@ steps:
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
+    # Ensure we have the latest remote state recorded locally
+    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER fetch github "refs/heads/${GH_BRANCH}:refs/remotes/github/${GH_BRANCH}" || true
+
+    # Overwrite the remote bot branch (safe force)
     git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
-      push github "HEAD:refs/heads/${GH_BRANCH}"
+      push --force-with-lease github "HEAD:refs/heads/${GH_BRANCH}"
 
     # ---- Build PR body safely (multiline-safe) ----
     PR_BODY="$(cat <<EOF

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -3,8 +3,7 @@ trigger: none
 pr:
   branches:
     include:
-      - ai/*
-      - copilot/*
+      - main
 
 pool:
   vmImage: ubuntu-latest
@@ -21,6 +20,18 @@ variables:
 steps:
 - checkout: self
   persistCredentials: true
+
+- bash: |
+    set -euo pipefail
+
+    echo "Build.Reason = $BUILD_REASON"
+    echo "Source branch = $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+
+    if [[ ! "$SYSTEM_PULLREQUEST_SOURCEBRANCH" =~ ^refs/heads/(ai|copilot)/ ]]; then
+      echo "Not an ai/* or copilot/* PR – exiting"
+      exit 0
+    fi
+  displayName: "Only allow ai/* or copilot/* source branches"
 
 - bash: |
     set -euo pipefail


### PR DESCRIPTION
## Description

Updates the GitHub authentication mechanism in the Azure DevOps pipeline (`tools/pipelines/ai/ai-pr.yml`) to use Basic authentication with base64-encoded credentials instead of bearer token authorization.

**Changes made:**
- Changed GitHub PAT git authentication from bearer token format to Basic auth with base64-encoded `x-access-token` credentials, removing newline characters from the encoded string via `tr -d '\n'`.
- Added a `fetch` before the push to populate the remote tracking ref, enabling safe `--force-with-lease` pushes to existing branches.
- Updated the ADO secret variable reference from `GH_PAT` to `GH_TEMP_PAT` to match the correct variable group name.
- Removed a redundant duplicate `git remote remove/add github` block that was being executed immediately before the auth header was built and again right after, leaving only a single canonical remote setup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The git push now uses `--force-with-lease` (instead of a plain `--force`) backed by a prior fetch, which is safer when multiple pipeline runs could target the same branch concurrently.
- The GitHub REST API call to create the PR still uses `Authorization: token ${GITHUB_PAT}` (raw PAT), which is correct for that endpoint — the base64 encoding applies only to the HTTPS git credential used by git itself.