### PR TITLE
fix: updating how auth info is encoded for github

### DIFF
--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -42,7 +42,6 @@ steps:
     echo "Target branch: $SYSTEM_PULLREQUEST_TARGETBRANCH"
 
     # Normalize branch name (refs/heads/ai/foo -> ai/foo)
-    SRC_BRANCH="${SYSTEM_PULLREQUEST_SOURCEBRANCH#refs/heads/}"
     GH_BRANCH="ado-${SYSTEM_PULLREQUEST_PULLREQUESTID}"
 
     echo "GitHub branch will be: $GH_BRANCH"
@@ -50,9 +49,9 @@ steps:
     # ---- Fetch PR title + description from ADO ----
     ADO_PR_API="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_apis/git/repositories/${BUILD_REPOSITORY_ID}/pullRequests/${SYSTEM_PULLREQUEST_PULLREQUESTID}?api-version=7.1"
 
-    PR_JSON=$(curl -sS \
+    PR_JSON=$(curl -sS --fail \
       -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-      "$ADO_PR_API")
+      "$ADO_PR_API" || { echo "Failed to fetch PR details"; exit 1; })
 
     PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
     PR_DESC=$(echo "$PR_JSON" | jq -r '.description')
@@ -98,12 +97,21 @@ steps:
 
     echo "Creating GitHub PR..."
 
-    curl -sS -X POST \
+    RESPONSE=$(curl -sS -w "%{http_code}" -o response.txt -X POST \
       -H "Authorization: token ${GITHUB_PAT}" \
       -H "Accept: application/vnd.github+json" \
       https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls \
-      -d "$CREATE_PR_PAYLOAD" \
-      || echo "PR may already exist — branch updated."
+      -d "$CREATE_PR_PAYLOAD")
+
+    if [ "$RESPONSE" -eq 201 ]; then
+      echo "GitHub PR created successfully."
+    elif [ "$RESPONSE" -eq 422 ]; then
+      echo "PR may already exist — branch updated."
+    else
+      echo "Failed to create GitHub PR. HTTP status: $RESPONSE"
+      cat response.txt
+      exit 1
+    fi
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -1,0 +1,98 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+      - ai/*
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+- group: ai-pr-bot-secrets
+- name: GITHUB_OWNER
+  value: microsoft
+- name: GITHUB_REPO
+  value: FluidFramework
+- name: GITHUB_BASE_BRANCH
+  value: main
+
+steps:
+- checkout: self
+  persistCredentials: true
+
+- bash: |
+    set -euo pipefail
+
+    echo "== Azure DevOps PR Context =="
+    echo "PR ID: $SYSTEM_PULLREQUEST_PULLREQUESTID"
+    echo "Source branch: $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+    echo "Target branch: $SYSTEM_PULLREQUEST_TARGETBRANCH"
+
+    # Normalize branch name (refs/heads/ai/foo -> ai/foo)
+    SRC_BRANCH="${SYSTEM_PULLREQUEST_SOURCEBRANCH#refs/heads/}"
+    GH_BRANCH="ado-${SYSTEM_PULLREQUEST_PULLREQUESTID}"
+
+    echo "GitHub branch will be: $GH_BRANCH"
+
+    # ---- Fetch PR title + description from ADO ----
+    ADO_PR_API="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_apis/git/repositories/${BUILD_REPOSITORY_ID}/pullRequests/${SYSTEM_PULLREQUEST_PULLREQUESTID}?api-version=7.1"
+
+    PR_JSON=$(curl -sS \
+      -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+      "$ADO_PR_API")
+
+    PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+    PR_DESC=$(echo "$PR_JSON" | jq -r '.description')
+
+    echo "== PR Title =="
+    echo "$PR_TITLE"
+
+    echo "== PR Description =="
+    echo "$PR_DESC"
+
+    # ---- Push branch to GitHub ----
+    git remote remove github 2>/dev/null || true
+    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
+
+    git config --global http.extraheader "Authorization: Bearer $GITHUB_PAT"
+
+
+    git push github HEAD:refs/heads/$GH_BRANCH --force
+
+    # ---- Build PR body safely (multiline-safe) ----
+    PR_BODY="$(cat <<EOF
+    ${PR_DESC}
+
+    🔗 **Source ADO PR:**
+    ${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_git/${BUILD_REPOSITORY_NAME}/pullrequest/${SYSTEM_PULLREQUEST_PULLREQUESTID}
+    EOF
+    )"
+
+    # ---- Create GitHub PR payload ----
+    CREATE_PR_PAYLOAD="$(jq -n \
+      --arg title "$PR_TITLE" \
+      --arg head "$GH_BRANCH" \
+      --arg base "$GITHUB_BASE_BRANCH" \
+      --arg body "$PR_BODY" \
+      '{
+        title: $title,
+        head: $head,
+        base: $base,
+        body: $body,
+        draft: true
+      }'
+    )"
+
+    echo "Creating GitHub PR..."
+
+    curl -sS -X POST \
+      -H "Authorization: token ${GITHUB_PAT}" \
+      -H "Accept: application/vnd.github+json" \
+      https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls \
+      -d "$CREATE_PR_PAYLOAD" \
+      || echo "PR may already exist — branch updated."
+
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    GITHUB_PAT: $(GITHUB_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -67,7 +67,8 @@ steps:
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
     # Map GitHub PAT into an env var (ADO secret variable -> env var)
-    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: bearer ${GITHUB_PAT}"
+    B64_AUTH=$(printf "x-access-token:%s" "${GITHUB_PAT}" | base64 | tr -d '\n')
+    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: Basic ${B64_AUTH}"
 
     # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
     git remote remove github 2>/dev/null || true

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -23,7 +23,7 @@ steps:
 
 - bash: |
     set -euo pipefail
-
+    # TODO: move this step below, where it will actually do things (currently here for now for testing)
     echo "Build.Reason = $BUILD_REASON"
     echo "Source branch = $SYSTEM_PULLREQUEST_SOURCEBRANCH"
 
@@ -43,39 +43,36 @@ steps:
 
     # Normalize branch name (refs/heads/ai/foo -> ai/foo)
     GH_BRANCH="ado-${SYSTEM_PULLREQUEST_PULLREQUESTID}"
-
     echo "GitHub branch will be: $GH_BRANCH"
 
     # ---- Fetch PR title + description from ADO ----
     ADO_PR_API="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${SYSTEM_TEAMPROJECTID}/_apis/git/repositories/${BUILD_REPOSITORY_ID}/pullRequests/${SYSTEM_PULLREQUEST_PULLREQUESTID}?api-version=7.1"
 
-    PR_JSON=$(curl -sS --fail \
+    PR_JSON="$(curl -sS --fail \
       -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-      "$ADO_PR_API" || { echo "Failed to fetch PR details"; exit 1; })
+      "$ADO_PR_API" \
+    )" || { echo "Failed to fetch PR details"; exit 1; }
 
-    PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-    PR_DESC=$(echo "$PR_JSON" | jq -r '.description')
+    PR_TITLE="$(echo "$PR_JSON" | jq -r '.title')"
+    PR_DESC="$(echo "$PR_JSON" | jq -r '.description // ""')"
 
     echo "== PR Title =="
     echo "$PR_TITLE"
-
     echo "== PR Description =="
     echo "$PR_DESC"
 
     # ---- Push branch to GitHub ----
-    git remote remove github 2>/dev/null || true
-    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
-
     # Map GitHub PAT into an env var (ADO secret variable -> env var)
-    B64_AUTH=$(printf "x-access-token:%s" "${GITHUB_PAT}" | base64 | tr -d '\n')
+    B64_AUTH="$(printf "x-access-token:%s" "${GITHUB_PAT}" | base64 | tr -d '\n')"
     export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: Basic ${B64_AUTH}"
 
-    # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
+    # Add GitHub remote WITHOUT embedding PAT in URL
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
-    # Ensure we have the latest remote state recorded locally
-    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER fetch github "refs/heads/${GH_BRANCH}:refs/remotes/github/${GH_BRANCH}" || true
+    # Ensure we have the latest remote state recorded locally (non-fatal if branch doesn't exist yet)
+    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
+      fetch github "refs/heads/${GH_BRANCH}:refs/remotes/github/${GH_BRANCH}" || true
 
     # Overwrite the remote bot branch (safe force)
     git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
@@ -106,23 +103,57 @@ steps:
     )"
 
     echo "Creating GitHub PR..."
-
-    RESPONSE=$(curl -sS -w "%{http_code}" -o response.txt -X POST \
-      -H "Authorization: token ${GITHUB_PAT}" \
+    CREATE_PR_RESPONSE="$(curl -sS --fail -X POST \
       -H "Accept: application/vnd.github+json" \
-      https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls \
-      -d "$CREATE_PR_PAYLOAD")
+      -H "Authorization: Bearer ${GITHUB_PAT}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls" \
+      -d "$CREATE_PR_PAYLOAD"
+    )" || { echo "Failed to create GitHub PR"; exit 1; }
 
-    if [ "$RESPONSE" -eq 201 ]; then
-      echo "GitHub PR created successfully."
-    elif [ "$RESPONSE" -eq 422 ]; then
-      echo "PR may already exist — branch updated."
-    else
-      echo "Failed to create GitHub PR. HTTP status: $RESPONSE"
-      cat response.txt
+    GITHUB_PR_NUMBER="$(echo "$CREATE_PR_RESPONSE" | jq -r '.number // empty')"
+    GITHUB_PR_URL="$(echo "$CREATE_PR_RESPONSE" | jq -r '.html_url // empty')"
+
+    if [[ -z "$GITHUB_PR_NUMBER" ]]; then
+      echo "Failed to create PR or missing PR number"
+      echo "$CREATE_PR_RESPONSE"
       exit 1
     fi
 
+    echo "Created GitHub PR #$GITHUB_PR_NUMBER"
+    if [[ -n "$GITHUB_PR_URL" ]]; then
+      echo "GitHub PR URL: $GITHUB_PR_URL"
+    fi
+
+    # ---- Summon the Copilot ----
+    SUMMON_COPILOT_MESSAGE="$(cat <<'EOF'
+    @Copilot
+
+    Please review this PR and implement the requested changes.
+    - Focus on correctness, tests, and repo conventions.
+    - If you need clarification, ask questions in this PR.
+    EOF
+    )"
+
+    COMMENT_PAYLOAD="$(jq -n --arg body "$SUMMON_COPILOT_MESSAGE" '{body: $body}')"
+
+    echo "Posting Copilot invocation comment..."
+    COMMENT_RESPONSE="$(curl -sS --fail -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${GITHUB_PAT}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues/${GITHUB_PR_NUMBER}/comments" \
+      -d "$COMMENT_PAYLOAD"
+    )" || { echo "Failed to post Copilot comment"; exit 1; }
+
+    COMMENT_URL="$(echo "$COMMENT_RESPONSE" | jq -r '.html_url // empty')"
+    if [[ -n "$COMMENT_URL" ]]; then
+      echo "Posted comment: $COMMENT_URL"
+    else
+      echo "Posted comment (no url returned)"
+    fi
+
+  displayName: "Mirror PR to GitHub + create PR + invoke Copilot"
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     GITHUB_PAT: $(GH_TEMP_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -121,4 +121,4 @@ steps:
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    GITHUB_PAT: $(GH_PAT)
+    GITHUB_PAT: $(GH_TEMP_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -66,10 +66,15 @@ steps:
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
-    git config --global http.extraheader "Authorization: Bearer $GITHUB_PAT"
+    # Map GitHub PAT into an env var (ADO secret variable -> env var)
+    export GIT_HTTP_EXTRAHEADER="AUTHORIZATION: bearer ${GITHUB_PAT}"
 
+    # Add GitHub remote WITHOUT embedding PAT in URL (keeps token out of remote URL too)
+    git remote remove github 2>/dev/null || true
+    git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
-    git push github HEAD:refs/heads/$GH_BRANCH --force
+    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
+      push github "HEAD:refs/heads/${GH_BRANCH}"
 
     # ---- Build PR body safely (multiline-safe) ----
     PR_BODY="$(cat <<EOF

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
       - ai/*
+      - copilot/*
 
 pool:
   vmImage: ubuntu-latest

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -11,7 +11,7 @@ pool:
 variables:
 - group: ai-pr-bot-secrets
 - name: GITHUB_OWNER
-  value: microsoft
+  value: jumyhre # TODO: Change to microsoft when ready
 - name: GITHUB_REPO
   value: FluidFramework
 - name: GITHUB_BASE_BRANCH

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -95,4 +95,4 @@ steps:
 
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    GITHUB_PAT: $(GITHUB_PAT)
+    GITHUB_PAT: $(GH_PAT)

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -36,6 +36,11 @@ steps:
 - bash: |
     set -euo pipefail
 
+    if [[ ! "$SYSTEM_PULLREQUEST_SOURCEBRANCH" =~ ^refs/heads/(ai|copilot)/ ]]; then
+      echo "Not an ai/* or copilot/* PR – exiting"
+      exit 0
+    fi
+
     echo "== Azure DevOps PR Context =="
     echo "PR ID: $SYSTEM_PULLREQUEST_PULLREQUESTID"
     echo "Source branch: $SYSTEM_PULLREQUEST_SOURCEBRANCH"

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -74,8 +74,12 @@ steps:
     git remote remove github 2>/dev/null || true
     git remote add github "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 
+    # Ensure we have the latest remote state recorded locally
+    git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER fetch github "refs/heads/${GH_BRANCH}:refs/remotes/github/${GH_BRANCH}" || true
+
+    # Overwrite the remote bot branch (safe force)
     git --config-env=http.extraheader=GIT_HTTP_EXTRAHEADER \
-      push github "HEAD:refs/heads/${GH_BRANCH}"
+      push --force-with-lease github "HEAD:refs/heads/${GH_BRANCH}"
 
     # ---- Build PR body safely (multiline-safe) ----
     PR_BODY="$(cat <<EOF

--- a/tools/pipelines/ai/ai-pr.yml
+++ b/tools/pipelines/ai/ai-pr.yml
@@ -3,8 +3,7 @@ trigger: none
 pr:
   branches:
     include:
-      - ai/*
-      - copilot/*
+      - main
 
 pool:
   vmImage: ubuntu-latest
@@ -21,6 +20,18 @@ variables:
 steps:
 - checkout: self
   persistCredentials: true
+
+- bash: |
+    set -euo pipefail
+
+    echo "Build.Reason = $BUILD_REASON"
+    echo "Source branch = $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+
+    if [[ ! "$SYSTEM_PULLREQUEST_SOURCEBRANCH" =~ ^refs/heads/(ai|copilot)/ ]]; then
+      echo "Not an ai/* or copilot/* PR – exiting"
+      exit 0
+    fi
+  displayName: "Only allow ai/* or copilot/* source branches"
 
 - bash: |
     set -euo pipefail


### PR DESCRIPTION
## Description

Updates the GitHub authentication mechanism in the Azure DevOps pipeline (`tools/pipelines/ai/ai-pr.yml`) with two correctness fixes:

- **Auth encoding**: Changed GitHub PAT authentication for git operations from bearer token format to Basic auth with base64-encoded `x-access-token:<PAT>` credentials (removing newline characters from the encoded string). GitHub's HTTPS git transport requires proper HTTP Basic auth credentials rather than bearer tokens.
- **Branch guard**: Added the `ai/*` / `copilot/*` source-branch check to the start of the mirror-and-create-PR step. Previously only the first (debug) step had the guard, so the git push and GitHub PR creation would execute for all PRs regardless of source branch.

## Reviewer Guidance

- The auth encoding change fixes git pushes to GitHub that were failing due to the incorrect `Authorization: bearer` header format.
- The branch guard fix ensures the pipeline only mirrors and creates PRs for `ai/*` or `copilot/*` source branches, not all ADO PRs targeting `main`.